### PR TITLE
Reduce the Flatpak size

### DIFF
--- a/org.kde.kcalc.json
+++ b/org.kde.kcalc.json
@@ -12,8 +12,10 @@
         "--socket=wayland"
     ],
     "cleanup": [
-        "/lib/*.a",
-        "/lib/*.la"
+        "/share/doc",
+        "/share/info",
+        "*.la",
+        "*.a"
     ],
     "modules": [
         {


### PR DESCRIPTION
### Total

The installed size reduced from 3.2 MB to 1.9 MB.

### Drop /share/doc folder

KDE apps usually open an external website for help documentation.

This app uses the following page:

https://docs.kde.org/stable_kf6/en/kcalc/kcalc/index.html

### Drop /share/info

Many projects drop this folder

See: https://github.com/search?q=org%3Aflathub%20%2Fshare%2Finfo&type=code
