### PR TITLE
Use the mpfr module from the runtime

### DIFF
--- a/org.kde.kcalc.json
+++ b/org.kde.kcalc.json
@@ -19,27 +19,6 @@
     ],
     "modules": [
         {
-            "name": "mpfr",
-            "cleanup": [
-                "/include",
-                "/lib/pkgconfig",
-                "/share/doc/mpfr"
-            ],
-            "sources": [
-                {
-                    "type": "archive",
-                    "url": "https://www.mpfr.org/mpfr-4.2.2/mpfr-4.2.2.tar.xz",
-                    "sha256": "b67ba0383ef7e8a8563734e2e889ef5ec3c3b898a01d00fa0a6869ad81c6ce01",
-                    "x-checker-data": {
-                        "type": "anitya",
-                        "project-id": 2019,
-                        "stable-only": true,
-                        "url-template": "https://www.mpfr.org/mpfr-$version/mpfr-$version.tar.xz"
-                    }
-                }
-            ]
-        },
-        {
             "name": "mpc",
             "cleanup": [
                 "/include",


### PR DESCRIPTION
KDE runtime version **6.10** (based on the Freedesktop runtime version **25.08**) appears to provide the **mpfr** module. 

In most cases, you don't need to build this module separately, unless your project requires a specific version or a custom configuration. 

Fixes: https://github.com/flathub/org.kde.kcalc/issues/91